### PR TITLE
Add ignore path configuration

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,0 +1,2 @@
+# Paths to be ignored by addlicense
+ignorePaths: ["test/**"]

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/google/addlicense
 
 go 1.13
 
-require golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+require (
+	github.com/gobwas/glob v0.2.3
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	gopkg.in/yaml.v2 v2.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,8 @@
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Adds option to provide a config file with paths that should be ignored by addlicense.
Uses github.com/gobwas/glob library to match glob patterns. Also adds some paths
that will be ignored by addlicense by default, e.g. node_modules or .git folders.
An example of a config file is also included.

Signed-off-by: Yann Jorelle <yann.jorelle@nokia.com>