### PR TITLE
Add file-extension commenting format configuration

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,2 +1,71 @@
 # Paths to be ignored by addlicense
 ignorePaths: ["test/**"]
+
+# File extension commenting format configuration
+fileExtensions:
+  - extensions: [".c", ".h"]
+    top: "/*"
+    mid: " * "
+    bot: "*/"
+  - extensions: [".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".tf", ".ts"]
+    top: "/**"
+    mid: " * "
+    bot: "*/"
+  - extensions:
+      [
+        ".cc",
+        ".cpp",
+        ".cs",
+        ".go",
+        ".hh",
+        ".hpp",
+        ".java",
+        ".m",
+        ".mm",
+        ".proto",
+        ".rs",
+        ".scala",
+        ".swift",
+        ".dart",
+        ".groovy",
+        ".kt",
+        ".kts",
+        ".php",
+      ]
+    top: ""
+    mid: "// "
+    bot: ""
+  - extensions:
+      [
+        ".py",
+        ".sh",
+        ".yaml",
+        ".yml",
+        ".dockerfile",
+        "dockerfile",
+        ".rb",
+        "gemfile",
+      ]
+    top: ""
+    mid: "# "
+    bot: ""
+  - extensions: [".el", ".lisp"]
+    top: ""
+    mid: ";; "
+    bot: ""
+  - extensions: [".erl"]
+    top: ""
+    mid: "% "
+    bot: ""
+  - extensions: [".hs", ".sql"]
+    top: ""
+    mid: "-- "
+    bot: ""
+  - extensions: [".html", ".xml", ".vue"]
+    top: "<!--"
+    mid: " "
+    bot: "-->"
+  - extensions: [".ml", ".mli", ".mll", ".mly"]
+    top: "(**"
+    mid: "   "
+    bot: "*)"


### PR DESCRIPTION
Adds option to pass in file-extension specific commenting formats in the config
file, instead of having to modify the source code. An example of this is
included in the examples/config.yml file.

Also adds a print statement in verbose mode if a file extension is not
supported.

Signed-off-by: Yann Jorelle <yann.jorelle@nokia.com>