### PR TITLE
Add hasLicense pattern configuration

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,6 +1,9 @@
 # Paths to be ignored by addlicense
 ignorePaths: ["test/**"]
 
+# Patterns to determine whether a file already has a license
+hasLicensePatterns: ["copyright"]
+
 # File extension commenting format configuration
 fileExtensions:
   - extensions: [".c", ".h"]


### PR DESCRIPTION
Adds ability to configure the patterns that determine whether a file already has a
license header.

Signed-off-by: Yann Jorelle <yann.jorelle@nokia.com>