### PR TITLE
Add dockerfile and basic scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.13 as build
+
+# Set working directory
+WORKDIR /addlicense
+
+# Download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source
+COPY . .
+
+# Build and install to /go/bin/addlicense
+RUN go install .
+
+# Make a minimal image
+FROM alpine:latest
+
+# Copy the binary from the build
+COPY --from=build /go/bin/addlicense /
+
+# Options for addlicense
+ENV OPTIONS ""
+
+WORKDIR /myapp
+
+ENTRYPOINT "../addlicense" ${OPTIONS} "."

--- a/build_addlicense.sh
+++ b/build_addlicense.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Build script to create addlicense container.
+# Example of building with specific tag: TAG="something" ./build_addlicense
+
+tag=${TAG:="latest"}
+echo "Building addlicense container with tag: $tag"
+docker build -t addlicense:$tag . || echo "Build failed."

--- a/run_addlicense.sh
+++ b/run_addlicense.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Script that runs the addlicense container.
+# Addlicense options can be passed to this script, but make sure you wrap them
+# in quotes ("").
+
+# Examples of how to use:
+# 1. Run addlicense with check option: ./run_addlicense "-check"
+# 2. Run addlicense with some more options: 
+#    ./run_addlicense "-v -config congig.yml -c Nokia"
+# 3. Run specific tag of the addlicense image: 
+#    TAG="something" ./run_addlicense.sh "-check"
+
+tag=${TAG:="latest"}
+docker run -e OPTIONS="$@" --rm -it -v $(pwd):/myapp addlicense:$tag


### PR DESCRIPTION
Adds a Dockerfile for addlicense and some basic scripts to build and run an
addlicense docker container.

Signed-off-by: Yann Jorelle <yann.jorelle@nokia.com>