### PR TITLE
Render the year in the license header

### DIFF
--- a/copyright-texts/apache-2.0
+++ b/copyright-texts/apache-2.0
@@ -1,3 +1,3 @@
-Copyright 2020 Nokia
+Copyright {{.Year}} Nokia
 Licensed under the Apache License 2.0.
 SPDX-License-Identifier: Apache-2.0

--- a/copyright-texts/bsd-3-clause
+++ b/copyright-texts/bsd-3-clause
@@ -1,3 +1,3 @@
-Copyright 2020 Nokia
+Copyright {{.Year}} Nokia
 Licensed under the BSD 3-Clause License.
 SPDX-License-Identifier: BSD-3-Clause

--- a/copyright-texts/mit
+++ b/copyright-texts/mit
@@ -1,3 +1,3 @@
-Copyright 2020 Nokia
+Copyright {{.Year}} Nokia
 Licensed under the MIT License.
 SPDX-License-Identifier: MIT


### PR DESCRIPTION
Change the hard coded year in the default headers to use the template rendering. 
Using the current year by default, can be changed by passing a value in the -y flag